### PR TITLE
Add the ability to define a custom request header size if you need bigger headers

### DIFF
--- a/src/RequestHeaderParser.php
+++ b/src/RequestHeaderParser.php
@@ -15,15 +15,16 @@ use RingCentral\Psr7 as g7;
 class RequestHeaderParser extends EventEmitter
 {
     private $buffer = '';
-    private $maxSize = 4096;
+    private $bufferMaxSize;
 
     private $localSocketUri;
     private $remoteSocketUri;
 
-    public function __construct($localSocketUri = null, $remoteSocketUri = null)
+    public function __construct($localSocketUri = null, $remoteSocketUri = null, $bufferMaxSize = null)
     {
         $this->localSocketUri = $localSocketUri;
         $this->remoteSocketUri = $remoteSocketUri;
+        $this->bufferMaxSize = is_integer($bufferMaxSize) ? $bufferMaxSize : 4096;
     }
 
     public function feed($data)
@@ -38,8 +39,8 @@ class RequestHeaderParser extends EventEmitter
             $currentHeaderSize = strlen($this->buffer);
         }
 
-        if ($currentHeaderSize > $this->maxSize) {
-            $this->emit('error', array(new \OverflowException("Maximum header size of {$this->maxSize} exceeded.", 431), $this));
+        if ($currentHeaderSize > $this->bufferMaxSize) {
+            $this->emit('error', array(new \OverflowException("Maximum header size of {$this->bufferMaxSize} exceeded.", 431), $this));
             $this->removeAllListeners();
             return;
         }

--- a/src/Server.php
+++ b/src/Server.php
@@ -77,6 +77,8 @@ class Server extends EventEmitter
 {
     private $callback;
 
+    private $options;
+
     /**
      * Creates an HTTP server that invokes the given callback for each incoming HTTP request
      *
@@ -86,15 +88,17 @@ class Server extends EventEmitter
      * See also [listen()](#listen) for more details.
      *
      * @param callable $callback
+     * @param array $options
      * @see self::listen()
      */
-    public function __construct($callback)
+    public function __construct($callback, array $options = [])
     {
         if (!is_callable($callback)) {
             throw new \InvalidArgumentException();
         }
 
         $this->callback = $callback;
+        $this->options = $options;
     }
 
     /**
@@ -147,25 +151,8 @@ class Server extends EventEmitter
     /** @internal */
     public function handleConnection(ConnectionInterface $conn)
     {
-        $uriLocal = $conn->getLocalAddress();
-        if ($uriLocal !== null && strpos($uriLocal, '://') === false) {
-            // local URI known but does not contain a scheme. Should only happen for old Socket < 0.8
-            // try to detect transport encryption and assume default application scheme
-            $uriLocal = ($this->isConnectionEncrypted($conn) ? 'https://' : 'http://') . $uriLocal;
-        } elseif ($uriLocal !== null) {
-            // local URI known, so translate transport scheme to application scheme
-            $uriLocal = strtr($uriLocal, array('tcp://' => 'http://', 'tls://' => 'https://'));
-        }
-
-        $uriRemote = $conn->getRemoteAddress();
-        if ($uriRemote !== null && strpos($uriRemote, '://') === false) {
-            // local URI known but does not contain a scheme. Should only happen for old Socket < 0.8
-            // actual scheme is not evaluated but required for parsing URI
-            $uriRemote = 'unused://' . $uriRemote;
-        }
-
         $that = $this;
-        $parser = new RequestHeaderParser($uriLocal, $uriRemote);
+        $parser = $this->getRequestHeaderParser($conn);
 
         $listener = array($parser, 'feed');
         $parser->on('headers', function (RequestInterface $request, $bodyBuffer) use ($conn, $listener, $parser, $that) {
@@ -421,6 +408,56 @@ class Server extends EventEmitter
 
             $connection->end();
         }
+    }
+
+    /**
+     * @param ConnectionInterface $conn
+     * @return RequestHeaderParser
+     */
+    private function getRequestHeaderParser(ConnectionInterface $conn)
+    {
+      $uriLocal = $this->getUriLocal($conn);
+      $uriRemote = $this->getUriRemote($conn);
+
+      if (isset($this->options['max_header_size']) && is_integer($this->options['max_header_size'])) {
+        return new RequestHeaderParser($uriLocal, $uriRemote, $this->options['max_header_size']);
+      }
+      return new RequestHeaderParser($uriLocal, $uriRemote);
+    }
+
+    /**
+     * @param ConnectionInterface $conn
+     * @return string
+     */
+    private function getUriLocal(ConnectionInterface $conn)
+    {
+      $uriLocal = $conn->getLocalAddress();
+      if ($uriLocal !== null && strpos($uriLocal, '://') === false) {
+        // local URI known but does not contain a scheme. Should only happen for old Socket < 0.8
+        // try to detect transport encryption and assume default application scheme
+        $uriLocal = ($this->isConnectionEncrypted($conn) ? 'https://' : 'http://') . $uriLocal;
+      } elseif ($uriLocal !== null) {
+        // local URI known, so translate transport scheme to application scheme
+        $uriLocal = strtr($uriLocal, array('tcp://' => 'http://', 'tls://' => 'https://'));
+      }
+
+      return $uriLocal;
+    }
+
+    /**
+     * @param ConnectionInterface $conn
+     * @return string
+     */
+    private function getUriRemote(ConnectionInterface $conn)
+    {
+      $uriRemote = $conn->getRemoteAddress();
+      if ($uriRemote !== null && strpos($uriRemote, '://') === false) {
+        // local URI known but does not contain a scheme. Should only happen for old Socket < 0.8
+        // actual scheme is not evaluated but required for parsing URI
+        $uriRemote = 'unused://' . $uriRemote;
+      }
+
+      return $uriRemote;
     }
 
     /**

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -1254,6 +1254,40 @@ class ServerTest extends TestCase
         $this->assertContains("\r\n\r\nError 431: Request Header Fields Too Large", $buffer);
     }
 
+    public function testCustomRequestHeaderSizeIsPassedAndNoHeaderOverflowErrorWillAppear()
+    {
+      $maxSize = 1024 * 16;
+
+      $options = [];
+      $options['max_header_size'] = $maxSize;
+
+      $server = new Server(function (ServerRequestInterface $request) {
+        return new Response(200, array());
+      }, $options);
+
+      $buffer = '';
+
+      $this->connection
+        ->expects($this->any())
+        ->method('write')
+        ->will(
+          $this->returnCallback(
+            function ($data) use (&$buffer) {
+              $buffer .= $data;
+            }
+          )
+        );
+
+      $server->listen($this->socket);
+      $this->socket->emit('connection', array($this->connection));
+
+      $data = "GET / HTTP/1.1\r\nHost: example.com\r\nConnection: close\r\nX-DATA: ";
+      $data .= str_repeat('A', 4097 - strlen($data)) . "\r\n\r\n";
+      $this->connection->emit('data', array($data));
+
+      $this->assertStringStartsWith("HTTP/1.1 200 OK\r\n", $buffer);
+    }
+
     public function testRequestInvalidWillEmitErrorAndSendErrorResponse()
     {
         $error = null;


### PR DESCRIPTION
This PR is a follow up of the discussion. This allows us to configure the server with a max_header_size and pass it down to the RequestHeaderParser. 

Question which I asked my self during implementation:
* Do we want to fallback silently on invalid parameter usage?
* Do we want to fail early on invalid parameter usage (i.e. fail on boot before the first request arrives)